### PR TITLE
Lambda function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+
+.python-version

--- a/docqanda/Dockerfile
+++ b/docqanda/Dockerfile
@@ -1,0 +1,34 @@
+ARG FUNCTION_DIR="/function"
+
+FROM --platform=linux/x86-64 ubuntu:22.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get install -y \
+  g++ \
+  make \
+  cmake \
+  unzip \
+  libcurl4-openssl-dev \
+  python3 \
+  python3-pip \
+  python3-dev
+
+RUN pip3 install awslambdaric
+
+ARG FUNCTION_DIR
+
+RUN mkdir -p ${FUNCTION_DIR}
+
+ADD . ${FUNCTION_DIR}
+
+WORKDIR ${FUNCTION_DIR}
+
+RUN pip3 install -r ${FUNCTION_DIR}/lambda.requirements.txt --target "${FUNCTION_DIR}"
+
+RUN python3 lambda.py
+
+ENTRYPOINT ["/usr/bin/python3", "-m", "awslambdaric"]
+
+CMD ["lambda.handler"]

--- a/docqanda/Makefile
+++ b/docqanda/Makefile
@@ -1,0 +1,2 @@
+image:
+	docker build -t docquanda .

--- a/docqanda/lambda.py
+++ b/docqanda/lambda.py
@@ -1,0 +1,47 @@
+import multiprocessing
+
+from langchain.embeddings import HuggingFaceEmbeddings, OpenAIEmbeddings
+from langchain.vectorstores import FAISS, Chroma
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.document_loaders import TextLoader, UnstructuredPDFLoader
+from langchain.chains import RetrievalQA
+from langchain.llms import GPT4All, LlamaCpp, OpenAI
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain.callbacks.stdout import StdOutCallbackHandler
+
+model = LlamaCpp(
+    model_path="models/ggml-alpaca-7b-q4.bin",
+    callbacks=[StreamingStdOutCallbackHandler(), StdOutCallbackHandler()],
+    n_ctx=1024,
+    n_threads=multiprocessing.cpu_count()
+)
+
+embedding = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+persist_directory = "database/"
+
+database = Chroma(persist_directory=persist_directory, embedding_function=embedding)
+
+retriever = database.as_retriever()
+
+qa = RetrievalQA.from_chain_type(llm=model, chain_type="stuff", retriever=retriever)
+
+
+def handler(event, context):
+    query = event["query"]
+
+    response = qa.run(query)
+
+    return {"response": response}
+
+
+if __name__ == "__main__":
+    loader = TextLoader("shakespeare.txt").load()
+
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=250, chunk_overlap=0)
+
+    documents = text_splitter.split_documents(loader)
+
+    database = Chroma.from_documents(documents=documents, embedding=embedding, persist_directory=persist_directory)
+
+    database.persist()

--- a/docqanda/lambda.requirements.txt
+++ b/docqanda/lambda.requirements.txt
@@ -1,0 +1,2 @@
+langchain==0.0.178
+llama-cpp-python==0.1.54


### PR DESCRIPTION
Here's an initial work of deploying a `RetrievalQA` inside of a Lambda function. The approach here is to load the sample dataset into a Chroma database and persist it during the image build phase. When the Lambda runs, it'll be able to open the database on-the-fly.

Steps to run:

1. Download `ggml-alpaca-7b-q4.bin` to the `models/` directory.
2. Run `make image`

Once the Docker image can be built, we can add a Terraform config to deploy the Lambda function to AWS. We can hook up the Lambda to the AWS API Gateway so that a web app can call it via a REST API.